### PR TITLE
Update adventure

### DIFF
--- a/Bukkit/build.gradle.kts
+++ b/Bukkit/build.gradle.kts
@@ -14,14 +14,21 @@ base {
 
 dependencies {
     implementation("cloud.commandframework:cloud-paper:${VersionConstants.cloudVersion}")
-    implementation("net.kyori:adventure-api:${VersionConstants.adventureVersion}")
-    implementation("net.kyori:adventure-platform-bukkit:${VersionConstants.adventurePlatformVersion}")
+    implementation("net.kyori:adventure-api:${VersionConstants.adventureVersion}") {
+        exclude("net.kyori", "adventure-text-minimessage")
+    }
+    implementation("net.kyori:adventure-platform-bukkit:${VersionConstants.adventurePlatformVersion}") {
+        exclude("net.kyori", "adventure-api")
+        exclude("net.kyori", "adventure-text-minimessage")
+    }
     implementation("net.kyori:adventure-text-minimessage:${VersionConstants.adventureMinimessageVersion}") {
         exclude("net.kyori", "adventure-api")
     }
     implementation("org.bstats:bstats-bukkit:${VersionConstants.bstatsVersion}")
     implementation(project(":Common"))
-    compileOnly("com.destroystokyo.paper:paper-api:1.16.5-R0.1-SNAPSHOT")
+    compileOnly("com.destroystokyo.paper:paper-api:1.16.5-R0.1-SNAPSHOT") {
+        exclude("net.kyori", "*")
+    }
 }
 
 tasks.withType<ShadowJar> {

--- a/Bungee/build.gradle.kts
+++ b/Bungee/build.gradle.kts
@@ -18,8 +18,13 @@ repositories {
 
 dependencies {
     implementation("cloud.commandframework:cloud-bungee:${VersionConstants.cloudVersion}")
-    implementation("net.kyori:adventure-api:${VersionConstants.adventureVersion}")
-    implementation("net.kyori:adventure-platform-bungeecord:${VersionConstants.adventurePlatformVersion}")
+    implementation("net.kyori:adventure-api:${VersionConstants.adventureVersion}") {
+        exclude("net.kyori", "adventure-text-minimessage")
+    }
+    implementation("net.kyori:adventure-platform-bungeecord:${VersionConstants.adventurePlatformVersion}") {
+        exclude("net.kyori", "adventure-api")
+        exclude("net.kyori", "adventure-text-minimessage")
+    }
     implementation("net.kyori:adventure-text-minimessage:${VersionConstants.adventureMinimessageVersion}") {
         exclude("net.kyori", "adventure-api")
     }

--- a/Common/build.gradle.kts
+++ b/Common/build.gradle.kts
@@ -15,8 +15,10 @@ repositories {
 }
 
 dependencies {
-    compileOnly("net.kyori:adventure-platform-api:${VersionConstants.adventurePlatformVersion}")
-    compileOnly("net.kyori:adventure-text-minimessage:${VersionConstants.adventureMinimessageVersion}")
+    compileOnly("net.kyori:adventure-platform-api:${VersionConstants.adventurePlatformVersion}") {
+        exclude("net.kyori", "adventure-api")
+        exclude("net.kyori", "adventure-text-minimessage")
+    }
     compileOnly("com.github.FrankHeijden:ServerUtilsUpdater:5f722b10d1")
 
     testImplementation("net.kyori:adventure-text-serializer-plain:${VersionConstants.adventureVersion}")

--- a/Common/build.gradle.kts
+++ b/Common/build.gradle.kts
@@ -19,6 +19,7 @@ dependencies {
         exclude("net.kyori", "adventure-api")
         exclude("net.kyori", "adventure-text-minimessage")
     }
+    compileOnly("net.kyori:adventure-text-minimessage:${VersionConstants.adventureMinimessageVersion}")
     compileOnly("com.github.FrankHeijden:ServerUtilsUpdater:5f722b10d1")
 
     testImplementation("net.kyori:adventure-text-serializer-plain:${VersionConstants.adventureVersion}")

--- a/buildSrc/src/main/kotlin/VersionConstants.kt
+++ b/buildSrc/src/main/kotlin/VersionConstants.kt
@@ -1,7 +1,7 @@
 object VersionConstants {
     const val cloudVersion = "1.8.0-SNAPSHOT"
-    const val adventureVersion = "4.9.3"
-    const val adventurePlatformVersion = "4.0.1"
+    const val adventureVersion = "4.11.0"
+    const val adventurePlatformVersion = "4.1.2"
     const val adventureMinimessageVersion = "4.2.0-SNAPSHOT"
     const val bstatsVersion = "3.0.0"
 }


### PR DESCRIPTION
Hello, there has been an issue with the kyori adventure api which has been sending some wrong packets or whatnot in the current version and basically didn't work properly with ViaVersion, updating it to 4.1.2 resolves the problem and everything works fine. So I managed to fix that by updating some parts of the adventure api.

There is more info on this adventure bug here: https://github.com/ViaVersion/ViaVersion/issues/3070